### PR TITLE
Add slide direction overrides and sync custom demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,144 @@
 # Flashcards
+
+A lightweight, dependency-free JavaScript library for building animated flip-style flashcards. The library exposes a single `FlashcardApp` class that can be used from a `<script>` tag, CommonJS, or AMD environments. It includes a CSS file with sensible defaults and optional transitions.
+
+## Features
+
+- Simple API for adding flashcard pages programmatically
+- Smooth flip animations with optional slide transitions between cards
+- Directional slide animations (left/right/up/down) with optional overlay arrows
+- Configurable dimensions, colours, and fonts globally or per card
+- Keyboard navigation (arrow keys) and click-to-flip interaction
+- Works in modern browsers without any build tooling
+
+## Getting started
+
+1. Include the CSS and JavaScript files in your page.
+
+   ```html
+   <link rel="stylesheet" href="/path/to/flashcard.css">
+   <script src="/path/to/flashcard.js"></script>
+   ```
+
+2. Create a container element for the app.
+
+   ```html
+   <div id="flashcardApp"></div>
+   ```
+
+3. Instantiate the library and add pages.
+
+   ```html
+   <script>
+     const app = new FlashcardLib.FlashcardApp({
+       width: '360px',
+       height: '240px',
+       frontColor: '#f8fafc',
+       backColor: '#fee2e2',
+       textColor: '#0f172a',
+       font: "'Inter', 'Segoe UI', sans-serif"
+     });
+
+     app
+       .addPage('What is the capital of Sweden?', 'Stockholm')
+       .addPage('2 + 2 = ?', '4')
+       .start('flashcardApp');
+   </script>
+   ```
+
+4. (Optional) Provide per-card overrides by passing a configuration object to `addPage`.
+
+   ```js
+   app.addPage('Primary colour?', 'Blue', {
+     frontColor: '#dbeafe',
+     backColor: '#1e3a8a',
+     textColor: '#0f172a'
+   });
+   ```
+
+### API reference
+
+#### `new FlashcardApp(options?)`
+
+Creates a new flashcard application instance. All properties are optional.
+
+| Option            | Type   | Default                                     | Description                                                                                |
+|-------------------|--------|---------------------------------------------|--------------------------------------------------------------------------------------------|
+| `width`           | string | `"300px"`                                  | Width of the flashcard.                                                                    |
+| `height`          | string | `"200px"`                                  | Height of the flashcard.                                                                   |
+| `font`            | string | `"'Inter', 'Segoe UI', Arial, sans-serif"` | Font family applied to both card faces.                                                    |
+| `frontColor`      | string | `"#ffffff"`                                | Background colour of the card front.                                                       |
+| `backColor`       | string | `"#ffebcd"`                                | Background colour of the card back.                                                        |
+| `textColor`       | string | `"#333333"`                                | Text colour for both faces.                                                                |
+| `navigationMode`  | string | `"buttons"`                                | Choose between `"buttons"`, `"side-arrows"`, `"vertical-arrows"`, or `"none"` for navigation controls. Aliases such as `"horizontal"`, `"horizontal-arrows"`, `"vertical"`, and `"top-bottom"` are also accepted. |
+| `slideDirection`  | string | `"left"`                                   | Direction for forward navigation: `"left"`, `"right"`, `"up"`, or `"down"`. Previous uses the opposite direction. |
+
+#### `.addPage(frontText, backText, pageConfig?)`
+
+Adds a flashcard page. Both text arguments must be strings. The optional `pageConfig` object accepts the same styling keys as the constructor, can additionally include a `backgroundColor` property for backwards compatibility (applies to both sides), and may set `navigationMode` or `slideDirection` to temporarily override the on-screen controls and animation direction for that specific card.
+
+#### Navigation modes & keyboard support
+
+- `navigationMode: "buttons"` renders the default previous/next buttons beneath the card.
+- `navigationMode: "side-arrows"` (or aliases like `"horizontal"`, `"horizontal-arrows"`, or `"left-right"`) hides the buttons and shows floating arrows on the left/right edges of the card.
+- `navigationMode: "vertical-arrows"` (or aliases like `"vertical"`, `"top-bottom"`, or `"up-down"`) hides the buttons and shows arrows above/below the card, ideal for vertical slides.
+- `navigationMode: "none"` removes on-screen navigation entirely—useful when you prefer keyboard controls or custom external buttons.
+
+When `slideDirection` is set to `"up"` or `"down"`, the app listens to <kbd>ArrowUp</kbd>/<kbd>ArrowDown</kbd> in addition to the horizontal arrow keys. Cards can temporarily change direction by providing `slideDirection` inside their `pageConfig`.
+
+You can swap navigation modes on the fly by calling `setNavigationMode(...)` or by providing `navigationMode` in a page's `pageConfig`. Cards without an explicit override fall back to the most recently persisted mode.
+
+#### `.setSlideDirection(direction, options?)`
+
+Updates the slide animation direction used when moving to the next card. Accepts `"left"`, `"right"`, `"up"`, or `"down"`. Pass `{ persist: false }` to make the change temporary so that the next non-overridden card reverts to the previously saved direction. As with navigation modes, you can also provide `slideDirection` on individual cards to request a particular animation for that card only.
+
+#### `.clearPages()`
+
+Removes all pages and resets the index.
+
+#### `.start(containerOrId?)`
+
+Renders the flashcards into the specified container (either the element itself or its `id`). Defaults to `"flashcardApp"`. Throws if no pages have been added or if the DOM is not available.
+
+#### `.destroy()`
+
+Removes global event listeners and clears cached DOM references. Call this before discarding an instance or reusing it elsewhere.
+
+#### `.setNavigationMode(mode, options?)`
+
+Updates the current navigation UI at runtime. Pass any of the supported modes (or their aliases) and the library will rebuild the controls instantly. An optional `{ persist: false }` flag keeps the change temporary—useful when alternating modes on a per-card basis. Without the flag the choice becomes the new default for subsequent cards that do not specify their own `navigationMode`.
+
+## Live examples
+
+Open the HTML files in the [`test/`](test) directory in a browser to see the library in action. Each example keeps the markup minimal and uses the shared `flashcard.css` and `flashcard.js` files.
+
+## Development
+
+This repository intentionally avoids build tooling. To make changes, edit `flashcard.js` and `flashcard.css`, then open one of the test HTML files locally (e.g. using a static file server such as `npx serve`).
+
+## Working with GitHub
+
+If you plan to tweak the library or contribute upstream using GitHub, the recommended workflow is:
+
+1. **Fork or clone the repository.** Use GitHub's *Fork* button if you do not have write access, or run `git clone <repo-url>` if you do.
+2. **Create a feature branch.** Run `git checkout -b my-feature` so that your work stays isolated from `main`.
+3. **Make your changes locally.** Update the JavaScript, CSS, and/or demo files as needed and open the HTML examples in `test/` to verify everything still works.
+4. **Run quick smoke checks.** For CommonJS builds you can run `node -e "const lib = require('./flashcard.js'); console.log(Object.keys(lib));"` to ensure the bundle exports correctly.
+5. **Commit with a clear message.** Stage your files (`git add ...`) and commit (`git commit -m "Describe your change"`).
+6. **Push the branch to GitHub.** Use `git push origin my-feature`.
+7. **Open a pull request.** From GitHub, compare your branch against the target branch (typically `main`), summarise the changes, list any manual testing you performed, and request a review.
+
+Following these steps keeps the history tidy and makes it easier for reviewers to understand and merge your improvements.
+
+### Troubleshooting GitHub permissions
+
+If GitHub shows the message `Det här kodförrådet är inte berättigat att skapa grenar. Kontrollera dina GitHub-behörigheter.` ("This repository is not eligible to create branches. Check your GitHub permissions."), it means you do not have write access to the repository. You can resolve this by either:
+
+- **Forking the repository.** Click **Fork** in the GitHub UI to create your own copy, then clone and push branches to your fork.
+- **Requesting access.** Ask a maintainer to grant you the required permissions so you can create branches directly in the original repository.
+
+After forking or receiving access, retry the `git checkout -b my-feature` and `git push origin my-feature` steps from the workflow above.
+
+## License
+
+MIT License. See [LICENSE](LICENSE).

--- a/flashcard.css
+++ b/flashcard.css
@@ -1,113 +1,265 @@
 .flashcard-container {
-            perspective: 1000px;
-        }
+  perspective: 1000px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+}
 
-        .flashcard {
-            width: 300px;
-            height: 200px;
-            position: relative;
-            transition: transform 0.6s;
-            transform-style: preserve-3d;
-            cursor: pointer;
-        }
+.flashcard-container.navigation-side-arrows {
+  padding: 0 40px;
+}
 
-        .flashcard.flip {
-            transform: rotateY(180deg);
-        }
+.flashcard-container.navigation-vertical-arrows {
+  padding: 40px 0;
+}
 
-        .card-face {
-            position: absolute;
-            width: 100%;
-            height: 100%;
-            backface-visibility: hidden;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            font-size: 1.2em;
-            border-radius: 10px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-            padding: 10px;
-            box-sizing: border-box;
-            text-align: center;
-        }
+.flashcard-container.navigation-none {
+  padding: 0;
+}
 
-        .card-front {
-            background-color: #ffffff;
-        }
+.flashcard {
+  width: 300px;
+  height: 200px;
+  position: relative;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+  cursor: pointer;
+}
 
-        .card-back {
-            background-color: #ffebcd;
-            transform: rotateY(180deg);
-        }
+.flashcard.flip {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.2em;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  padding: 16px;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.card-front {
+  background-color: #ffffff;
+}
+
+.card-back {
+  background-color: #ffebcd;
+  transform: rotateY(180deg);
+}
+
 .slide-left-out {
-            animation: slideLeftOut 0.3s forwards;
-        }
+  animation: slideLeftOut 0.3s forwards;
+}
 
-        .slide-left-in {
-            animation: slideLeftIn 0.3s forwards;
-        }
+.slide-left-in {
+  animation: slideLeftIn 0.3s forwards;
+}
 
-        .slide-right-out {
-            animation: slideRightOut 0.3s forwards;
-        }
+.slide-right-out {
+  animation: slideRightOut 0.3s forwards;
+}
 
-        .slide-right-in {
-            animation: slideRightIn 0.3s forwards;
-        }
+.slide-right-in {
+  animation: slideRightIn 0.3s forwards;
+}
 
-        @keyframes slideLeftOut {
-            from {
-                transform: translateX(0);
-                opacity: 1;
-            }
+.slide-up-out {
+  animation: slideUpOut 0.3s forwards;
+}
 
-            to {
-                transform: translateX(-100%);
-                opacity: 0;
-            }
-        }
+.slide-up-in {
+  animation: slideUpIn 0.3s forwards;
+}
 
-        @keyframes slideLeftIn {
-            from {
-                transform: translateX(100%);
-                opacity: 0;
-            }
+.slide-down-out {
+  animation: slideDownOut 0.3s forwards;
+}
 
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
+.slide-down-in {
+  animation: slideDownIn 0.3s forwards;
+}
 
-        @keyframes slideRightOut {
-            from {
-                transform: translateX(0);
-                opacity: 1;
-            }
+@keyframes slideLeftOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
 
-            to {
-                transform: translateX(100%);
-                opacity: 0;
-            }
-        }
+  to {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+}
 
-        @keyframes slideRightIn {
-            from {
-                transform: translateX(-100%);
-                opacity: 0;
-            }
+@keyframes slideLeftIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
 
-            to {
-                transform: translateX(0);
-                opacity: 1;
-            }
-        }
- .card-nav-buttons {
-            margin-top: 20px;
-            text-align: center;
-        }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
 
-        button {
-            padding: 8px 16px;
-            margin: 0 8px;
-        }
+@keyframes slideRightOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}
+
+@keyframes slideRightIn {
+  from {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideUpOut {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  to {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+}
+
+@keyframes slideUpIn {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideDownOut {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  to {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+}
+
+@keyframes slideDownIn {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.nav-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+.nav-buttons button {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.nav-buttons button:disabled {
+  background-color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.nav-buttons button:not(:disabled):hover {
+  background-color: #1d4ed8;
+}
+
+.flashcard-arrow {
+  position: absolute;
+  border: none;
+  background: rgba(15, 23, 42, 0.45);
+  color: #f8fafc;
+  font-size: 1.5rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.flashcard-arrow:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.flashcard-arrow:not(:disabled):hover,
+.flashcard-arrow:not(:disabled):focus {
+  background: rgba(15, 23, 42, 0.65);
+  transform: scale(1.05);
+}
+
+.arrow-horizontal {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.arrow-left {
+  left: -20px;
+}
+
+.arrow-right {
+  right: -20px;
+}
+
+.arrow-vertical {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.arrow-top {
+  top: -20px;
+}
+
+.arrow-bottom {
+  bottom: -20px;
+}

--- a/flashcard.js
+++ b/flashcard.js
@@ -1,118 +1,530 @@
- class FlashcardPageConfig {
-      constructor({ font, textColor, backgroundColor }) {
-        this.font = font;
-        this.textColor = textColor;
-        this.backgroundColor = backgroundColor;
-      }
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    const exports = factory();
+    root.FlashcardLib = exports;
+    root.FlashcardApp = exports.FlashcardApp;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : this, function () {
+  const DEFAULT_STYLE = {
+    width: '300px',
+    height: '200px',
+    font: "'Inter', 'Segoe UI', Arial, sans-serif",
+    frontColor: '#ffffff',
+    backColor: '#ffebcd',
+    textColor: '#333333'
+  };
+
+  const VALID_DIRECTIONS = new Set(['left', 'right', 'up', 'down']);
+
+  const ANIMATION_CLASSES = [
+    'slide-left-out',
+    'slide-left-in',
+    'slide-right-out',
+    'slide-right-in',
+    'slide-up-out',
+    'slide-up-in',
+    'slide-down-out',
+    'slide-down-in'
+  ];
+
+  const DIRECTION_CLASS_MAP = {
+    left: {
+      out: 'slide-left-out',
+      in: 'slide-left-in'
+    },
+    right: {
+      out: 'slide-right-out',
+      in: 'slide-right-in'
+    },
+    up: {
+      out: 'slide-up-out',
+      in: 'slide-up-in'
+    },
+    down: {
+      out: 'slide-down-out',
+      in: 'slide-down-in'
+    }
+  };
+
+  const OPPOSITE_DIRECTION = {
+    left: 'right',
+    right: 'left',
+    up: 'down',
+    down: 'up'
+  };
+
+  const VALID_NAVIGATION_MODES = new Set(['buttons', 'side-arrows', 'vertical-arrows', 'none']);
+
+  const NAVIGATION_MODE_ALIASES = {
+    buttons: 'buttons',
+    button: 'buttons',
+    btns: 'buttons',
+    controls: 'buttons',
+    'side-arrows': 'side-arrows',
+    side: 'side-arrows',
+    horizontal: 'side-arrows',
+    'horizontal-arrows': 'side-arrows',
+    'left-right': 'side-arrows',
+    arrows: 'side-arrows',
+    'vertical-arrows': 'vertical-arrows',
+    vertical: 'vertical-arrows',
+    'top-bottom': 'vertical-arrows',
+    'bottom-top': 'vertical-arrows',
+    'up-down': 'vertical-arrows',
+    'down-up': 'vertical-arrows',
+    none: 'none',
+    hidden: 'none',
+    off: 'none'
+  };
+
+  const normalizeDirection = (direction, fallback = 'left') => {
+    if (typeof direction !== 'string') {
+      return fallback;
     }
 
-    class FlashcardApp {
-      constructor({ width, height, font, frontColor, backColor, textColor }) {
-        this.style = { width, height, font, frontColor, backColor, textColor };
-        this.pages = [];
-        this.currentIndex = 0;
+    const trimmed = direction.trim().toLowerCase();
+    return VALID_DIRECTIONS.has(trimmed) ? trimmed : fallback;
+  };
+
+  const normalizeNavigationMode = (mode, fallback = 'buttons') => {
+    if (typeof mode !== 'string') {
+      return fallback;
+    }
+
+    const trimmed = mode.trim().toLowerCase();
+    const normalized = NAVIGATION_MODE_ALIASES[trimmed] || trimmed;
+    return VALID_NAVIGATION_MODES.has(normalized) ? normalized : fallback;
+  };
+
+  class FlashcardApp {
+    constructor(options = {}) {
+      const {
+        navigationMode = 'buttons',
+        slideDirection = 'left',
+        ...styleOverrides
+      } = options;
+
+      this.style = { ...DEFAULT_STYLE, ...styleOverrides };
+      this.navigationMode = normalizeNavigationMode(navigationMode);
+      this._preferredNavigationMode = this.navigationMode;
+      this.slideDirection = normalizeDirection(slideDirection);
+      this._preferredSlideDirection = this.slideDirection;
+      this.pages = [];
+      this.currentIndex = 0;
+      this._keydownHandler = null;
+      this._isTransitioning = false;
+      this._elements = null;
+      this._applyNavigationMode = null;
+      this._updateNavigationState = null;
+    }
+
+    addPage(frontText, backText, config = {}) {
+      if (typeof frontText !== 'string' || typeof backText !== 'string') {
+        throw new TypeError('Flashcard pages require string values for both the front and the back text.');
       }
 
-      addPage(frontText, backText, config = null) {
-        this.pages.push({ front: frontText, back: backText, config });
+      this.pages.push({
+        front: frontText,
+        back: backText,
+        config: { ...config }
+      });
+
+      return this;
+    }
+
+    clearPages() {
+      this.pages = [];
+      this.currentIndex = 0;
+      return this;
+    }
+
+    destroy() {
+      if (typeof document !== 'undefined' && this._keydownHandler) {
+        document.removeEventListener('keydown', this._keydownHandler);
       }
 
-      start(containerId = 'flashcardApp') {
-        const container = document.getElementById(containerId);
-        container.innerHTML = '';
+      this._keydownHandler = null;
+      this._elements = null;
+      this._isTransitioning = false;
+      this._applyNavigationMode = null;
+      this._updateNavigationState = null;
+      return this;
+    }
 
-        const cardContainer = document.createElement('div');
-        cardContainer.className = 'flashcard-container';
+    setNavigationMode(mode, options = {}) {
+      const { persist = true } = options;
+      const normalized = normalizeNavigationMode(mode, this.navigationMode);
 
-        const card = document.createElement('div');
-        card.className = 'flashcard';
-        card.style.width = this.style.width;
-        card.style.height = this.style.height;
+      if (persist) {
+        this._preferredNavigationMode = normalized;
+      }
 
-        const front = document.createElement('div');
-        front.className = 'card-face card-front';
+      if (normalized !== this.navigationMode) {
+        this.navigationMode = normalized;
+      }
 
-        const back = document.createElement('div');
-        back.className = 'card-face card-back';
+      if (this._applyNavigationMode) {
+        this._applyNavigationMode(this.navigationMode);
+      }
 
-        card.appendChild(front);
-        card.appendChild(back);
-        cardContainer.appendChild(card);
-        container.appendChild(cardContainer);
+      if (this._updateNavigationState) {
+        this._updateNavigationState();
+      }
 
-        const nav = document.createElement('div');
-        nav.className = 'nav-buttons';
-        nav.innerHTML = `
-          <button id="prevBtn">Föregående</button>
-          <button id="nextBtn">Nästa</button>
-        `;
-        container.appendChild(nav);
+      return this;
+    }
 
-        card.addEventListener('click', () => {
-          card.classList.toggle('flip');
-        });
+    setSlideDirection(direction, options = {}) {
+      const { persist = true } = options;
+      const normalized = normalizeDirection(direction, this.slideDirection);
 
-        const renderCard = () => {
-          const { front: frontText, back: backText, config } = this.pages[this.currentIndex];
+      if (persist) {
+        this._preferredSlideDirection = normalized;
+      }
 
-          const effectiveFont = config?.font || this.style.font;
-          const effectiveFrontBg = config?.backgroundColor || this.style.frontColor;
-          const effectiveBackBg = config?.backgroundColor || this.style.backColor;
-          const effectiveTextColor = config?.textColor || this.style.textColor;
+      this.slideDirection = normalized;
 
-          front.textContent = frontText;
-          back.textContent = backText;
+      return this;
+    }
 
-          [front, back].forEach(el => {
-            el.style.fontFamily = effectiveFont;
-            el.style.color = effectiveTextColor;
+    start(containerOrId = 'flashcardApp') {
+      if (typeof document === 'undefined') {
+        throw new Error('FlashcardApp requires a browser environment with a DOM to render.');
+      }
+
+      if (this.pages.length === 0) {
+        throw new Error('No flashcard pages have been added. Use addPage before calling start.');
+      }
+
+      const container =
+        typeof containerOrId === 'string'
+          ? document.getElementById(containerOrId)
+          : containerOrId;
+
+      if (!container) {
+        throw new Error('Unable to locate the container element for the flashcard application.');
+      }
+
+      this.destroy();
+
+      container.innerHTML = '';
+
+      const cardContainer = document.createElement('div');
+      cardContainer.className = 'flashcard-container';
+
+      const card = document.createElement('div');
+      card.className = 'flashcard';
+
+      const front = document.createElement('div');
+      front.className = 'card-face card-front';
+
+      const back = document.createElement('div');
+      back.className = 'card-face card-back';
+
+      card.appendChild(front);
+      card.appendChild(back);
+      cardContainer.appendChild(card);
+      container.appendChild(cardContainer);
+
+      let prevControl = null;
+      let nextControl = null;
+      let nav = null;
+
+      this._elements = {
+        container,
+        card,
+        front,
+        back,
+        prevControl: null,
+        nextControl: null,
+        nav: null
+      };
+
+      const detachControls = () => {
+        if (prevControl) {
+          prevControl.removeEventListener('click', goToPrevious);
+          if (prevControl.parentNode) {
+            prevControl.parentNode.removeChild(prevControl);
+          }
+        }
+
+        if (nextControl) {
+          nextControl.removeEventListener('click', goToNext);
+          if (nextControl.parentNode) {
+            nextControl.parentNode.removeChild(nextControl);
+          }
+        }
+
+        if (nav && nav.parentNode) {
+          nav.parentNode.removeChild(nav);
+        }
+
+        prevControl = null;
+        nextControl = null;
+        nav = null;
+      };
+
+      const rebuildNavigation = (mode) => {
+        const normalized = normalizeNavigationMode(mode, this.navigationMode);
+
+        detachControls();
+
+        ['navigation-buttons', 'navigation-side-arrows', 'navigation-vertical-arrows', 'navigation-none'].forEach(className =>
+          cardContainer.classList.remove(className)
+        );
+        cardContainer.classList.add(`navigation-${normalized}`);
+
+        if (normalized === 'buttons') {
+          nav = document.createElement('div');
+          nav.className = 'nav-buttons';
+
+          const prevBtn = document.createElement('button');
+          prevBtn.type = 'button';
+          prevBtn.textContent = 'Previous';
+
+          const nextBtn = document.createElement('button');
+          nextBtn.type = 'button';
+          nextBtn.textContent = 'Next';
+
+          nav.appendChild(prevBtn);
+          nav.appendChild(nextBtn);
+          container.appendChild(nav);
+
+          prevControl = prevBtn;
+          nextControl = nextBtn;
+        } else if (normalized !== 'none') {
+          const createArrowButton = (className, label) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `flashcard-arrow ${className}`;
+            button.innerHTML = label;
+            return button;
+          };
+
+          if (normalized === 'side-arrows') {
+            prevControl = createArrowButton('arrow-horizontal arrow-left', '&#10094;');
+            prevControl.setAttribute('aria-label', 'Previous card');
+            nextControl = createArrowButton('arrow-horizontal arrow-right', '&#10095;');
+            nextControl.setAttribute('aria-label', 'Next card');
+          } else if (normalized === 'vertical-arrows') {
+            prevControl = createArrowButton('arrow-vertical arrow-top', '&#9650;');
+            prevControl.setAttribute('aria-label', 'Previous card');
+            nextControl = createArrowButton('arrow-vertical arrow-bottom', '&#9660;');
+            nextControl.setAttribute('aria-label', 'Next card');
+          }
+
+          [prevControl, nextControl].forEach(control => {
+            if (control) {
+              cardContainer.appendChild(control);
+            }
           });
+        }
 
-          front.style.backgroundColor = effectiveFrontBg;
-          back.style.backgroundColor = effectiveBackBg;
-        };
-
-        const transitionToCard = (newIndex, direction = 'left') => {
-          card.classList.remove('flip');
-          const outClass = direction === 'left' ? 'slide-left-out' : 'slide-right-out';
-          const inClass = direction === 'left' ? 'slide-left-in' : 'slide-right-in';
-
-          card.classList.add(outClass);
-
-          card.addEventListener('animationend', () => {
-            this.currentIndex = newIndex;
-            renderCard();
-            card.classList.remove(outClass);
-            card.classList.add(inClass);
-
-            card.addEventListener('animationend', () => {
-              card.classList.remove(inClass);
-            }, { once: true });
-
-          }, { once: true });
-        };
-
-        document.getElementById('prevBtn').onclick = () => {
-          if (this.currentIndex > 0) {
-            transitionToCard(this.currentIndex - 1, 'right');
-          }
-        };
-
-        document.getElementById('nextBtn').onclick = () => {
-          if (this.currentIndex < this.pages.length - 1) {
-            transitionToCard(this.currentIndex + 1, 'left');
-          }
-        };
-
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'ArrowRight' && this.currentIndex < this.pages.length - 1) {
-            transitionToCard(this.currentIndex + 1, 'left');
-          }
-          if (e.key === 'ArrowLeft' && this.currentIndex > 0) {
-            transitionToCard(this.currentIndex - 1, 'right');
+        [prevControl, nextControl].forEach(control => {
+          if (control) {
+            control.addEventListener('click', control === prevControl ? goToPrevious : goToNext);
           }
         });
 
-        renderCard();
-      }
+        this._elements.prevControl = prevControl;
+        this._elements.nextControl = nextControl;
+        this._elements.nav = nav;
+      };
+
+      const resetAnimations = () => {
+        ANIMATION_CLASSES.forEach(className => card.classList.remove(className));
+      };
+
+      const animateCard = (className, onComplete) => {
+        if (!className) {
+          onComplete();
+          return;
+        }
+
+        let resolved = false;
+
+        const finish = () => {
+          if (resolved) {
+            return;
+          }
+          resolved = true;
+          card.classList.remove(className);
+          onComplete();
+        };
+
+        const handleAnimationEnd = (event) => {
+          if (event.target !== card) {
+            return;
+          }
+          card.removeEventListener('animationend', handleAnimationEnd);
+          if (typeof window !== 'undefined') {
+            window.clearTimeout(fallbackTimer);
+          }
+          finish();
+        };
+
+        card.addEventListener('animationend', handleAnimationEnd);
+
+        const fallbackTimer = typeof window !== 'undefined'
+          ? window.setTimeout(() => {
+              card.removeEventListener('animationend', handleAnimationEnd);
+              finish();
+            }, 400)
+          : null;
+
+        card.classList.add(className);
+      };
+
+      const applyCardStyle = (style) => {
+        card.style.width = style.width;
+        card.style.height = style.height;
+
+        [front, back].forEach(element => {
+          element.style.fontFamily = style.font;
+          element.style.color = style.textColor;
+        });
+
+        front.style.backgroundColor = style.frontColor;
+        back.style.backgroundColor = style.backColor;
+      };
+
+      const renderCard = () => {
+        const { front: frontText, back: backText, config = {} } = this.pages[this.currentIndex];
+        const {
+          navigationMode: cardNavigationMode,
+          slideDirection: cardSlideDirection,
+          ...cardStyleOverrides
+        } = config;
+
+        if (config && Object.prototype.hasOwnProperty.call(config, 'navigationMode')) {
+          const desiredMode = normalizeNavigationMode(cardNavigationMode, this.navigationMode);
+          if (desiredMode !== this.navigationMode) {
+            this.setNavigationMode(desiredMode, { persist: false });
+          }
+        } else if (this.navigationMode !== this._preferredNavigationMode) {
+          this.setNavigationMode(this._preferredNavigationMode, { persist: false });
+        }
+
+        if (config && Object.prototype.hasOwnProperty.call(config, 'slideDirection')) {
+          const desiredDirection = normalizeDirection(cardSlideDirection, this.slideDirection);
+          if (desiredDirection !== this.slideDirection) {
+            this.setSlideDirection(desiredDirection, { persist: false });
+          }
+        } else if (this.slideDirection !== this._preferredSlideDirection) {
+          this.setSlideDirection(this._preferredSlideDirection, { persist: false });
+        }
+
+        const mergedStyle = {
+          ...this.style,
+          ...cardStyleOverrides,
+          frontColor:
+            cardStyleOverrides.frontColor ??
+            cardStyleOverrides.backgroundColor ??
+            this.style.frontColor,
+          backColor:
+            cardStyleOverrides.backColor ??
+            cardStyleOverrides.backgroundColor ??
+            this.style.backColor,
+          textColor: cardStyleOverrides.textColor ?? this.style.textColor
+        };
+
+        card.classList.remove('flip');
+        front.textContent = frontText;
+        back.textContent = backText;
+        applyCardStyle(mergedStyle);
+      };
+
+      const updateNavigationState = () => {
+        const atStart = this.currentIndex === 0;
+        const atEnd = this.currentIndex === this.pages.length - 1;
+
+        const updateControl = (control, disabled) => {
+          if (!control) {
+            return;
+          }
+
+          control.disabled = disabled;
+          control.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+        };
+
+        updateControl(prevControl, atStart);
+        updateControl(nextControl, atEnd);
+      };
+
+      const transitionToCard = (newIndex, direction = 'left') => {
+        if (newIndex === this.currentIndex || newIndex < 0 || newIndex >= this.pages.length) {
+          return;
+        }
+
+        if (this._isTransitioning) {
+          return;
+        }
+
+        this._isTransitioning = true;
+        resetAnimations();
+        card.classList.remove('flip');
+
+        const normalizedDirection = normalizeDirection(direction, 'left');
+        const { out: outClass, in: inClass } = DIRECTION_CLASS_MAP[normalizedDirection];
+
+        animateCard(outClass, () => {
+          this.currentIndex = newIndex;
+          renderCard();
+          resetAnimations();
+
+          animateCard(inClass, () => {
+            resetAnimations();
+            this._isTransitioning = false;
+            updateNavigationState();
+          });
+        });
+      };
+
+      const goToPrevious = () => {
+        const direction = normalizeDirection(OPPOSITE_DIRECTION[this.slideDirection] || 'right', 'right');
+        transitionToCard(this.currentIndex - 1, direction);
+      };
+
+      const goToNext = () => {
+        transitionToCard(this.currentIndex + 1, this.slideDirection);
+      };
+
+      card.addEventListener('click', () => {
+        if (this._isTransitioning) {
+          return;
+        }
+
+        card.classList.toggle('flip');
+      });
+
+      const keydownHandler = (event) => {
+        const orientation = this.slideDirection === 'up' || this.slideDirection === 'down' ? 'vertical' : 'horizontal';
+
+        if (event.key === 'ArrowRight' || (orientation === 'vertical' && event.key === 'ArrowDown')) {
+          goToNext();
+        }
+
+        if (event.key === 'ArrowLeft' || (orientation === 'vertical' && event.key === 'ArrowUp')) {
+          goToPrevious();
+        }
+      };
+
+      document.addEventListener('keydown', keydownHandler);
+
+      this._keydownHandler = keydownHandler;
+      this._applyNavigationMode = rebuildNavigation;
+      this._updateNavigationState = updateNavigationState;
+      rebuildNavigation(this.navigationMode);
+      renderCard();
+      updateNavigationState();
+
+      return this;
     }
+  }
+
+  return { FlashcardApp };
+});

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flashcard Library – Basic Example</title>
+    <link rel="stylesheet" href="../flashcard.css" />
+    <style>
+      body {
+        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, #e0f2fe, #fae8ff);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="flashcardApp"></div>
+
+    <script src="../flashcard.js"></script>
+    <script>
+      const capitals = [
+        { city: 'Stockholm', country: 'Sweden' },
+        { city: 'Tokyo', country: 'Japan' },
+        { city: 'Buenos Aires', country: 'Argentina' },
+        { city: 'Nairobi', country: 'Kenya' },
+        { city: 'Reykjavík', country: 'Iceland' }
+      ];
+
+      const app = new FlashcardLib.FlashcardApp();
+
+      capitals.forEach(({ city, country }) => {
+        app.addPage(city, `Country: ${country}`);
+      });
+
+      app.start('flashcardApp');
+    </script>
+  </body>
+</html>

--- a/test/custom-styles.html
+++ b/test/custom-styles.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flashcard Library – Custom Styles</title>
+    <link rel="stylesheet" href="../flashcard.css" />
+    <style>
+      body {
+        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+        margin: 0;
+        padding: 32px;
+        background-color: #0f172a;
+        color: #e2e8f0;
+        display: grid;
+        place-items: center;
+        gap: 24px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.5rem, 2vw + 1rem, 2.5rem);
+      }
+
+      .hint {
+        margin: 0;
+        text-align: center;
+        color: #94a3b8;
+        max-width: 48ch;
+      }
+
+      .control-panel {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .control-panel label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        color: #cbd5f5;
+      }
+
+      .control-panel select {
+        background: #1e293b;
+        color: #f8fafc;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        border-radius: 6px;
+        padding: 6px 10px;
+        font-size: 0.95rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Custom Themed Cards</h1>
+    <p class="hint">
+      Adjust the controls in real time&mdash;the deck will respect your preference unless a card asks for a special layout or
+      animation.
+    </p>
+    <div class="control-panel">
+      <label for="navModePicker">
+        Navigation controls:
+        <select id="navModePicker">
+          <option value="buttons">Buttons</option>
+          <option value="side-arrows">Side arrows</option>
+          <option value="vertical-arrows">Vertical arrows</option>
+          <option value="none">Hidden</option>
+        </select>
+      </label>
+    </div>
+    <div id="flashcardCustom"></div>
+
+    <script src="../flashcard.js"></script>
+    <script>
+      const animals = [
+        {
+          latin: 'Vulpes vulpes',
+          name: 'Red Fox',
+          navigationMode: 'buttons',
+          slideDirection: 'right',
+          style: { frontColor: '#f97316', backColor: '#7c2d12', textColor: '#fff7ed' }
+        },
+        {
+          latin: 'Delphinus delphis',
+          name: 'Common Dolphin',
+          navigationMode: 'side-arrows',
+          slideDirection: 'right',
+          style: { frontColor: '#0ea5e9', backColor: '#0f172a', textColor: '#e0f2fe' }
+        },
+        {
+          latin: 'Strigops habroptilus',
+          name: 'Kākāpō',
+          navigationMode: 'vertical-arrows',
+          slideDirection: 'down',
+          style: { frontColor: '#bef264', backColor: '#3f6212', textColor: '#0f172a' }
+        },
+        {
+          latin: 'Ambystoma mexicanum',
+          name: 'Axolotl',
+          navigationMode: 'none',
+          slideDirection: 'left',
+          style: { frontColor: '#38bdf8', backColor: '#082f49', textColor: '#f0f9ff' }
+        },
+        {
+          latin: 'Ailuropoda melanoleuca',
+          name: 'Giant Panda',
+          style: { frontColor: '#f1f5f9', backColor: '#1e293b', textColor: '#0f172a' }
+        }
+      ];
+
+      const app = new FlashcardLib.FlashcardApp({
+        width: '380px',
+        height: '240px',
+        frontColor: '#1e293b',
+        backColor: '#0f172a',
+        textColor: '#e2e8f0',
+        font: "'Fira Sans', 'Inter', sans-serif",
+        navigationMode: 'buttons',
+        slideDirection: 'right'
+      });
+
+      animals.forEach(({ latin, name, navigationMode, slideDirection, style }) => {
+        const config = { ...style };
+
+        if (navigationMode) {
+          config.navigationMode = navigationMode;
+        }
+
+        if (slideDirection) {
+          config.slideDirection = slideDirection;
+        }
+
+        app.addPage(`Latin: ${latin}`, `Common name: ${name}`, config);
+      });
+
+      app.start('flashcardCustom');
+
+      const picker = document.getElementById('navModePicker');
+      const navDirectionDefaults = {
+        buttons: 'right',
+        'side-arrows': 'right',
+        'vertical-arrows': 'down'
+      };
+
+      let preferredDirection = navDirectionDefaults[picker.value] || app.slideDirection;
+
+      const applyNavigationPreference = (mode) => {
+        app.setNavigationMode(mode);
+
+        if (navDirectionDefaults[mode]) {
+          preferredDirection = navDirectionDefaults[mode];
+        }
+
+        app.setSlideDirection(preferredDirection);
+      };
+
+      picker.addEventListener('change', (event) => {
+        applyNavigationPreference(event.target.value);
+      });
+
+      applyNavigationPreference(picker.value);
+    </script>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flashcard Library – Example Gallery</title>
+    <style>
+      body {
+        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at top, #fef3c7, #bfdbfe);
+      }
+
+      main {
+        background: rgba(255, 255, 255, 0.9);
+        padding: clamp(24px, 4vw, 48px);
+        border-radius: 16px;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+        max-width: 480px;
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 24px 0 0;
+        display: grid;
+        gap: 12px;
+      }
+
+      a {
+        color: #1d4ed8;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Flashcard Library Examples</h1>
+      <p>Open any of the following demos to see the flashcard component in action:</p>
+      <ul>
+        <li><a href="basic.html">Basic usage</a></li>
+        <li><a href="custom-styles.html">Custom styling & dynamic controls</a></li>
+        <li><a href="vertical-arrows.html">Vertical navigation demo</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/test/vertical-arrows.html
+++ b/test/vertical-arrows.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flashcard Library – Vertical Arrows</title>
+    <link rel="stylesheet" href="../flashcard.css" />
+    <style>
+      body {
+        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at bottom, #f0fdf4, #dcfce7 40%, #bbf7d0);
+      }
+
+      h1 {
+        margin-bottom: 24px;
+        color: #166534;
+        text-align: center;
+      }
+
+      main {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Street Food Snacks</h1>
+      <div id="flashcardVertical"></div>
+    </main>
+
+    <script src="../flashcard.js"></script>
+    <script>
+      const snacks = [
+        { emoji: '🌮', dish: 'Taco al pastor', city: 'Mexico City', country: 'Mexico' },
+        { emoji: '🥙', dish: 'Falafel pita', city: 'Jerusalem', country: 'Israel' },
+        { emoji: '🥟', dish: 'Jiaozi dumplings', city: 'Beijing', country: 'China' },
+        { emoji: '🥘', dish: 'Paella', city: 'Valencia', country: 'Spain' }
+      ];
+
+      const app = new FlashcardLib.FlashcardApp({
+        navigationMode: 'top-bottom',
+        slideDirection: 'down'
+      });
+
+      snacks.forEach(({ emoji, dish, city, country }) => {
+        app.addPage(`${emoji} ${dish}`, `Where to try it: ${city}, ${country}`);
+      });
+
+      app.start('flashcardVertical');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a setSlideDirection helper and track the preferred animation direction alongside navigation preferences
- let individual cards request temporary slide direction overrides while restoring the saved preference afterwards
- update the custom styles demo to pair navigation mode changes with matching directions and showcase vertical, hidden, and reversed cards

## Testing
- node -e "const lib = require('./flashcard.js'); console.log(Object.keys(lib));"

------
https://chatgpt.com/codex/tasks/task_e_68e60508b2c0832b9c3c1f90d688991b